### PR TITLE
Add support for docker-compose.yml "restart" key on services

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,6 +41,7 @@ type Service struct {
 	Ports               []PortBinding
 	User                *string
 	WorkingDir          string
+	Restart             string
 
 	// helpers for ensureNoDependsOnCycle
 	recStack         bool
@@ -276,6 +277,7 @@ func parseServiceYAML2_1(serviceYAML *service2_1) (*Service, error) {
 		Image:      serviceYAML.Image,
 		User:       serviceYAML.User,
 		WorkingDir: serviceYAML.WorkingDir,
+		Restart:    serviceYAML.Restart,
 	}
 
 	ports, err := parsePorts(serviceYAML.Ports)

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -251,6 +251,7 @@ type service2_1 struct {
 	User        *string             `mapdecode:"user"`
 	Volumes     []string            `mapdecode:"volumes"`
 	WorkingDir  string              `mapdecode:"working_dir"`
+	Restart     string              `mapdecode:"restart"`
 }
 
 type composeFile2_1 struct {

--- a/pkg/up/up.go
+++ b/pkg/up/up.go
@@ -448,6 +448,21 @@ func (u *upRunner) createServicesAndGetPodHostAliasesOnce() ([]v1.HostAlias, err
 	return u.hostAliases.v, u.hostAliases.err
 }
 
+func getRestartPolicyforService(app *app) v1.RestartPolicy {
+	var restartPolicy v1.RestartPolicy
+	switch app.composeService.Restart {
+	case "no":
+		restartPolicy = v1.RestartPolicyNever
+	case "always":
+		restartPolicy = v1.RestartPolicyAlways
+	case "on-failure":
+		restartPolicy = v1.RestartPolicyOnFailure
+	default:
+		restartPolicy = v1.RestartPolicyNever
+	}
+	return restartPolicy
+}
+
 // TODO: https://github.com/jbrekelmans/kube-compose/issues/64
 // nolint
 func (u *upRunner) createPod(app *app) (*v1.Pod, error) {
@@ -523,7 +538,7 @@ func (u *upRunner) createPod(app *app) (*v1.Pod, error) {
 				},
 			},
 			HostAliases:     hostAliases,
-			RestartPolicy:   v1.RestartPolicyNever,
+			RestartPolicy:   getRestartPolicyforService(app),
 			SecurityContext: securityContext,
 		},
 	}

--- a/pkg/up/up_test.go
+++ b/pkg/up/up_test.go
@@ -1,0 +1,73 @@
+package up
+
+import (
+	"testing"
+
+	"github.com/jbrekelmans/kube-compose/pkg/config"
+)
+
+func newTestConfig() *config.Config {
+	serviceA := &config.Service{
+		Name:    "a",
+		Restart: "no",
+	}
+	serviceB := &config.Service{
+		Name:    "b",
+		Restart: "always",
+	}
+	serviceC := &config.Service{
+		Name:    "c",
+		Restart: "on-failure",
+	}
+	serviceD := &config.Service{
+		Name: "d",
+	}
+
+	cfg := &config.Config{
+		CanonicalComposeFile: config.CanonicalComposeFile{
+			Services: map[string]*config.Service{
+				serviceA.Name: serviceA,
+				serviceB.Name: serviceB,
+				serviceC.Name: serviceC,
+				serviceD.Name: serviceD,
+			},
+		},
+	}
+	return cfg
+}
+
+func newTestApp(serviceName string) *app {
+	cfg := newTestConfig()
+	app := &app{
+		composeService: cfg.CanonicalComposeFile.Services[serviceName],
+	}
+	return app
+}
+func TestRestartPolicyforService_never(t *testing.T) {
+	app := newTestApp("a")
+	str := getRestartPolicyforService(app)
+	if str != "Never" {
+		t.Fail()
+	}
+}
+func TestRestartPolicyforService_always(t *testing.T) {
+	app := newTestApp("b")
+	str := getRestartPolicyforService(app)
+	if str != "Always" {
+		t.Fail()
+	}
+}
+func TestRestartPolicyforService_onfailure(t *testing.T) {
+	app := newTestApp("c")
+	str := getRestartPolicyforService(app)
+	if str != "OnFailure" {
+		t.Fail()
+	}
+}
+func TestRestartPolicyforService_default(t *testing.T) {
+	app := newTestApp("d")
+	str := getRestartPolicyforService(app)
+	if str != "Never" {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Added support for the restart key declared in docker-compose.yaml
The field will be mapped to pod definition based on the below logic
if docker-compose.restart = no then pod.restartPolicy = Never
if docker-compose.restart = always then pod.restartPolicy = Always
if docker-compose.restart = on-failure then restartPolicy = OnFailure

issue: #85