### PR TITLE
Issue #130

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -13,6 +13,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+var envGetter = os.LookupEnv
+
 func setFromKubeConfig(cfg *config.Config) error {
 	loader := clientcmd.NewDefaultClientConfigLoadingRules()
 	overrides := clientcmd.ConfigOverrides{}
@@ -47,7 +49,7 @@ func getEnvIDFlag(cmd *cobra.Command) (string, error) {
 	var envID string
 	var exists bool
 	if !cmd.Flags().Changed("env-id") {
-		envID, exists = os.LookupEnv("KUBECOMPOSE_ENVID")
+		envID, exists = envGetter("KUBECOMPOSE_ENVID")
 		if !exists {
 			return "", fmt.Errorf("either the flag --env-id or the environment variable KUBECOMPOSE_ENVID must be set")
 		}
@@ -61,7 +63,7 @@ func getNamespaceFlag(cmd *cobra.Command) (string, bool) {
 	var namespace string
 	var exists bool
 	if !cmd.Flags().Changed("namespace") {
-		namespace, exists = os.LookupEnv("KUBECOMPOSE_NAMESPACE")
+		namespace, exists = envGetter("KUBECOMPOSE_NAMESPACE")
 		if !exists {
 			return "", false
 		}

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -13,6 +13,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+const envVarPrefix = "KUBECOMPOSE_"
+
 var envGetter = os.LookupEnv
 
 func setFromKubeConfig(cfg *config.Config) error {
@@ -34,8 +36,8 @@ func setFromKubeConfig(cfg *config.Config) error {
 
 func getFileFlag(cmd *cobra.Command) (*string, error) {
 	var file *string
-	if cmd.Flags().Changed("file") {
-		fileStr, err := cmd.Flags().GetString("file")
+	if cmd.Flags().Changed(fileFlagName) {
+		fileStr, err := cmd.Flags().GetString(fileFlagName)
 		if err != nil {
 			return nil, err
 		}
@@ -48,28 +50,28 @@ func getFileFlag(cmd *cobra.Command) (*string, error) {
 func getEnvIDFlag(cmd *cobra.Command) (string, error) {
 	var envID string
 	var exists bool
-	if !cmd.Flags().Changed("env-id") {
-		envID, exists = envGetter("KUBECOMPOSE_ENVID")
+	if !cmd.Flags().Changed(envIDFlagName) {
+		envID, exists = envGetter(envVarPrefix + "ENVID")
 		if !exists {
-			return "", fmt.Errorf("either the flag --env-id or the environment variable KUBECOMPOSE_ENVID must be set")
+			return "", fmt.Errorf("either the flag --env-id or the environment variable %sENVID must be set", envVarPrefix)
 		}
 		return envID, nil
 	}
-	envID, _ = cmd.Flags().GetString("env-id")
+	envID, _ = cmd.Flags().GetString(envIDFlagName)
 	return envID, nil
 }
 
 func getNamespaceFlag(cmd *cobra.Command) (string, bool) {
 	var namespace string
 	var exists bool
-	if !cmd.Flags().Changed("namespace") {
-		namespace, exists = envGetter("KUBECOMPOSE_NAMESPACE")
+	if !cmd.Flags().Changed(namespaceFlagName) {
+		namespace, exists = envGetter(envVarPrefix + "NAMESPACE")
 		if !exists {
 			return "", false
 		}
 		return namespace, true
 	}
-	namespace, _ = cmd.Flags().GetString("namespace")
+	namespace, _ = cmd.Flags().GetString(namespaceFlagName)
 	return namespace, true
 }
 

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -68,7 +68,7 @@ func getNamespaceFlag(cmd *cobra.Command) (string, bool) {
 		return namespace, true
 	}
 	namespace, _ = cmd.Flags().GetString("namespace")
-	return namespace, false
+	return namespace, true
 }
 
 func getCommandConfig(cmd *cobra.Command, args []string) (*config.Config, error) {

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -44,7 +44,7 @@ func TestGetEnvIDFlag_FlagIsSet(t *testing.T) {
 	withMockedEnv(map[string]string{}, func() {
 		cmd := &cobra.Command{}
 		setRootCommandFlags(cmd)
-		cmd.ParseFlags([]string{"--env-id", "123"})
+		_ = cmd.ParseFlags([]string{"--" + envIDFlagName, "123"})
 		key, err := getEnvIDFlag(cmd)
 		if key != "123" || err != nil {
 			t.Fail()
@@ -78,7 +78,7 @@ func TestGetNamespaceFlag_FlagIsSet(t *testing.T) {
 	withMockedEnv(map[string]string{}, func() {
 		cmd := &cobra.Command{}
 		setRootCommandFlags(cmd)
-		cmd.ParseFlags([]string{"--namespace", "test"})
+		_ = cmd.ParseFlags([]string{"--" + namespaceFlagName, "test"})
 		key, exists := getNamespaceFlag(cmd)
 		if key != "test" || exists != true {
 			t.Fail()

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -1,54 +1,63 @@
 package cmd
 
 import (
-	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
 )
 
+func withMockedEnv(mockEnv map[string]string, callback func()) {
+	fsOld := envGetter
+	defer func() {
+		envGetter = fsOld
+	}()
+	envGetter = func(name string) (string, bool) {
+		value, ok := mockEnv[name]
+		return value, ok
+	}
+	callback()
+}
+
 func TestGetEnvIDFlag_EnvLookUpExists(t *testing.T) {
-	cmd := &cobra.Command{}
-	os.Setenv("KUBECOMPOSE_ENVID", "123")
-	key, err := getEnvIDFlag(cmd)
-	if key != "123" {
-		t.Fail()
-	}
-	if err != nil {
-		t.Fail()
-	}
+	withMockedEnv(map[string]string{
+		"KUBECOMPOSE_ENVID": "12345",
+	}, func() {
+		cmd := &cobra.Command{}
+		key, err := getEnvIDFlag(cmd)
+		if key != "12345" || err != nil {
+			t.Fail()
+		}
+	})
 }
 
 func TestGetEnvIDFlag_EnvLookUpNotExists(t *testing.T) {
-	cmd := &cobra.Command{}
-	key, err := getEnvIDFlag(cmd)
-	if key == "123" {
-		t.Fail()
-	}
-	if err == nil {
-		t.Fail()
-	}
+	withMockedEnv(map[string]string{}, func() {
+		cmd := &cobra.Command{}
+		key, err := getEnvIDFlag(cmd)
+		if key == "123" || err == nil {
+			t.Fail()
+		}
+	})
 }
 
 func TestGetNamespaceFlag_EnvLookUpExists(t *testing.T) {
-	cmd := &cobra.Command{}
-	os.Setenv("KUBECOMPOSE_NAMESPACE", "123")
-	key, exists := getNamespaceFlag(cmd)
-	if key != "123" {
-		t.Fail()
-	}
-	if exists == false {
-		t.Fail()
-	}
+	withMockedEnv(map[string]string{
+		"KUBECOMPOSE_NAMESPACE": "1234",
+	}, func() {
+		cmd := &cobra.Command{}
+		key, exists := getNamespaceFlag(cmd)
+		if key != "1234" || exists == false {
+			t.Fail()
+		}
+	})
 }
 
 func TestGetNamespaceFlag_EnvLookUpNotExists(t *testing.T) {
-	cmd := &cobra.Command{}
-	key, exists := getNamespaceFlag(cmd)
-	if key == "123" {
-		t.Fail()
-	}
-	if exists == true {
-		t.Fail()
-	}
+	withMockedEnv(map[string]string{}, func() {
+		cmd := &cobra.Command{}
+		key, exists := getNamespaceFlag(cmd)
+		if key == "12" || exists == true {
+			t.Fail()
+		}
+	})
 }

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestGetEnvIDFlag_EnvLookUpExists(t *testing.T) {
+	cmd := &cobra.Command{}
+	os.Setenv("KUBECOMPOSE_ENVID", "123")
+	key, err := getEnvIDFlag(cmd)
+	if key != "123" {
+		t.Fail()
+	}
+	if err != nil {
+		t.Fail()
+	}
+}
+
+func TestGetEnvIDFlag_EnvLookUpNotExists(t *testing.T) {
+	cmd := &cobra.Command{}
+	key, err := getEnvIDFlag(cmd)
+	if key == "123" {
+		t.Fail()
+	}
+	if err == nil {
+		t.Fail()
+	}
+}
+
+func TestGetNamespaceFlag_EnvLookUpExists(t *testing.T) {
+	cmd := &cobra.Command{}
+	os.Setenv("KUBECOMPOSE_NAMESPACE", "123")
+	key, exists := getNamespaceFlag(cmd)
+	if key != "123" {
+		t.Fail()
+	}
+	if exists == false {
+		t.Fail()
+	}
+}
+
+func TestGetNamespaceFlag_EnvLookUpNotExists(t *testing.T) {
+	cmd := &cobra.Command{}
+	key, exists := getNamespaceFlag(cmd)
+	if key == "123" {
+		t.Fail()
+	}
+	if exists == true {
+		t.Fail()
+	}
+}

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -34,7 +34,19 @@ func TestGetEnvIDFlag_EnvLookUpNotExists(t *testing.T) {
 	withMockedEnv(map[string]string{}, func() {
 		cmd := &cobra.Command{}
 		key, err := getEnvIDFlag(cmd)
-		if key == "123" || err == nil {
+		if key != "" || err == nil {
+			t.Fail()
+		}
+	})
+}
+
+func TestGetEnvIDFlag_FlagIsSet(t *testing.T) {
+	withMockedEnv(map[string]string{}, func() {
+		cmd := &cobra.Command{}
+		setRootCommandFlags(cmd)
+		cmd.ParseFlags([]string{"--env-id", "123"})
+		key, err := getEnvIDFlag(cmd)
+		if key != "123" || err != nil {
 			t.Fail()
 		}
 	})
@@ -56,7 +68,19 @@ func TestGetNamespaceFlag_EnvLookUpNotExists(t *testing.T) {
 	withMockedEnv(map[string]string{}, func() {
 		cmd := &cobra.Command{}
 		key, exists := getNamespaceFlag(cmd)
-		if key == "12" || exists == true {
+		if key != "" || exists == true {
+			t.Fail()
+		}
+	})
+}
+
+func TestGetNamespaceFlag_FlagIsSet(t *testing.T) {
+	withMockedEnv(map[string]string{}, func() {
+		cmd := &cobra.Command{}
+		setRootCommandFlags(cmd)
+		cmd.ParseFlags([]string{"--namespace", "test"})
+		key, exists := getNamespaceFlag(cmd)
+		if key != "test" || exists != true {
 			t.Fail()
 		}
 	})

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -21,8 +21,5 @@ func downCommand(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := down.Run(cfg); err != nil {
-		return err
-	}
-	return nil
+	return down.Run(cfg)
 }

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"log"
-
 	"github.com/jbrekelmans/kube-compose/pkg/down"
 	"github.com/spf13/cobra"
 )
@@ -13,18 +11,18 @@ func newDownCli() *cobra.Command {
 		Short: "Deletes the pods of the specified docker compose services. " +
 			"If all docker compose services would be deleted then the Kubernetes services are also deleted.",
 		Long: "destroy all pods and services",
-		Run:  downCommand,
+		RunE: downCommand,
 	}
 	return downCmd
 }
 
-func downCommand(cmd *cobra.Command, args []string) {
+func downCommand(cmd *cobra.Command, args []string) error {
 	cfg, err := getCommandConfig(cmd, args)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
-	err = down.Run(cfg)
-	if err != nil {
-		log.Fatal(err)
+	if err := down.Run(cfg); err != nil {
+		return err
 	}
+	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,32 +5,25 @@ import (
 	"github.com/spf13/viper"
 )
 
-var rootCmd = &cobra.Command{
-	Use:     "kube-compose",
-	Short:   "k8s",
-	Long:    "Environments on k8s made easy",
-	Version: "0.3.0",
-}
-
 func Execute() error {
-	rootCmd.AddCommand(newDownCli(), newUpCli(), newGetCli())
-	return rootCmd.Execute()
-}
-
-// This method is generated when cobra is initialized.
-// Flags and configuration settings are meant to be
-// configured here.
-// nolint
-func init() {
 	viper.SetEnvPrefix("kubecompose")
-	namespace := new(string)
-	rootCmd.PersistentFlags().StringVarP(namespace, "namespace", "n", "", "namespace for environment")
-	rootCmd.PersistentFlags().StringP("file", "f", "", "Specify an alternate compose file")
 	envID := new(string)
+	namespace := new(string)
+
+	rootCmd := &cobra.Command{
+		Use:     "kube-compose",
+		Short:   "k8s",
+		Long:    "Environments on k8s made easy",
+		Version: "0.3.0",
+	}
+
+	rootCmd.AddCommand(newDownCli(), newUpCli(), newGetCli())
+	rootCmd.PersistentFlags().StringP("file", "f", "", "Specify an alternate compose file")
 	rootCmd.PersistentFlags().StringVarP(envID, "env-id", "e", "", "used to isolate environments deployed to a shared namespace, "+
 		"by (1) using this value as a suffix of pod and service names and (2) using this value to isolate selectors. Either this flag or "+
 		"the environment variable KUBECOMPOSE_ENVID must be set")
 	viper.AutomaticEnv()
+
 	if *namespace == "" && viper.GetString("namespace") != "" {
 		// check if environment variable is set
 		*namespace = viper.GetString("namespace")
@@ -42,4 +35,5 @@ func init() {
 	} else {
 		_ = rootCmd.MarkPersistentFlagRequired("env-id")
 	}
+	return rootCmd.Execute()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,15 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+)
+
+const (
+	fileFlagName      = "file"
+	namespaceFlagName = "namespace"
+	envIDFlagName     = "env-id"
 )
 
 func Execute() error {
@@ -17,9 +25,9 @@ func Execute() error {
 }
 
 func setRootCommandFlags(rootCmd *cobra.Command) {
-	rootCmd.PersistentFlags().StringP("file", "f", "", "Specify an alternate compose file")
-	rootCmd.PersistentFlags().StringP("namespace", "n", "", "namespace for environment")
-	rootCmd.PersistentFlags().StringP("env-id", "e", "", "used to isolate environments deployed to a shared namespace, "+
+	rootCmd.PersistentFlags().StringP(fileFlagName, "f", "", "Specify an alternate compose file")
+	rootCmd.PersistentFlags().StringP(namespaceFlagName, "n", "", "namespace for environment")
+	rootCmd.PersistentFlags().StringP(envIDFlagName, "e", "", "used to isolate environments deployed to a shared namespace, "+
 		"by (1) using this value as a suffix of pod and service names and (2) using this value to isolate selectors. Either this flag or "+
-		"the environment variable KUBECOMPOSE_ENVID must be set")
+		fmt.Sprintf("the environment variable %sENVID must be set", envVarPrefix))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,38 +2,19 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 func Execute() error {
-	viper.SetEnvPrefix("kubecompose")
-	envID := new(string)
-	namespace := new(string)
-
 	rootCmd := &cobra.Command{
 		Use:     "kube-compose",
 		Short:   "k8s",
 		Long:    "Environments on k8s made easy",
 		Version: "0.3.0",
 	}
-
 	rootCmd.AddCommand(newDownCli(), newUpCli(), newGetCli())
 	rootCmd.PersistentFlags().StringP("file", "f", "", "Specify an alternate compose file")
-	rootCmd.PersistentFlags().StringVarP(envID, "env-id", "e", "", "used to isolate environments deployed to a shared namespace, "+
+	rootCmd.PersistentFlags().StringP("env-id", "e", "", "used to isolate environments deployed to a shared namespace, "+
 		"by (1) using this value as a suffix of pod and service names and (2) using this value to isolate selectors. Either this flag or "+
 		"the environment variable KUBECOMPOSE_ENVID must be set")
-	viper.AutomaticEnv()
-
-	if *namespace == "" && viper.GetString("namespace") != "" {
-		// check if environment variable is set
-		*namespace = viper.GetString("namespace")
-	}
-	// TODO https://github.com/jbrekelmans/kube-compose/issues/80 this does not have a hyphen whereas the flag does. What does AutomaticEnv
-	// do?
-	if *envID == "" && viper.GetString("envid") != "" {
-		*envID = viper.GetString("envid")
-	} else {
-		_ = rootCmd.MarkPersistentFlagRequired("env-id")
-	}
 	return rootCmd.Execute()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,9 +12,14 @@ func Execute() error {
 		Version: "0.3.0",
 	}
 	rootCmd.AddCommand(newDownCli(), newUpCli(), newGetCli())
+	setRootCommandFlags(rootCmd)
+	return rootCmd.Execute()
+}
+
+func setRootCommandFlags(rootCmd *cobra.Command) {
 	rootCmd.PersistentFlags().StringP("file", "f", "", "Specify an alternate compose file")
+	rootCmd.PersistentFlags().StringP("namespace", "n", "", "namespace for environment")
 	rootCmd.PersistentFlags().StringP("env-id", "e", "", "used to isolate environments deployed to a shared namespace, "+
 		"by (1) using this value as a suffix of pod and service names and (2) using this value to isolate selectors. Either this flag or "+
 		"the environment variable KUBECOMPOSE_ENVID must be set")
-	return rootCmd.Execute()
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"log"
 
 	"github.com/jbrekelmans/kube-compose/pkg/up"
 	"github.com/spf13/cobra"
@@ -13,7 +12,7 @@ func newUpCli() *cobra.Command {
 		Use:   "up",
 		Short: "Create and start containers running on K8s",
 		Long:  "creates pods and services in an order that respects depends_on in the docker compose file",
-		Run:   upCommand,
+		RunE:  upCommand,
 	}
 	upCmd.PersistentFlags().BoolP("detach", "d", false, "Detached mode: Run containers in the background")
 	upCmd.PersistentFlags().BoolP("run-as-user", "", false, "When set, the runAsUser/runAsGroup will be set for each pod based on the "+
@@ -21,16 +20,16 @@ func newUpCli() *cobra.Command {
 	return upCmd
 }
 
-func upCommand(cmd *cobra.Command, args []string) {
+func upCommand(cmd *cobra.Command, args []string) error {
 	cfg, err := getCommandConfig(cmd, args)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	opts := &up.Options{}
 	opts.Detach, _ = cmd.Flags().GetBool("detach")
 	opts.RunAsUser, _ = cmd.Flags().GetBool("run-as-user")
-	err = up.Run(context.Background(), cfg, opts)
-	if err != nil {
-		log.Fatal(err)
+	if err := up.Run(context.Background(), cfg, opts); err != nil {
+		return err
 	}
+	return nil
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -28,8 +28,5 @@ func upCommand(cmd *cobra.Command, args []string) error {
 	opts := &up.Options{}
 	opts.Detach, _ = cmd.Flags().GetBool("detach")
 	opts.RunAsUser, _ = cmd.Flags().GetBool("run-as-user")
-	if err := up.Run(context.Background(), cfg, opts); err != nil {
-		return err
-	}
-	return nil
+	return up.Run(context.Background(), cfg, opts)
 }


### PR DESCRIPTION
Fixes:
- #130
- #131
- #133
- #80 closed due to using `os.Getenv()` rather than using viper